### PR TITLE
fix(pades): align inferred hash with explicit OID and EC curve size

### DIFF
--- a/src/SimpleSign.PAdES/DeferredSigner.cs
+++ b/src/SimpleSign.PAdES/DeferredSigner.cs
@@ -52,10 +52,12 @@ public static class DeferredSigner
 
         options ??= new DeferredSigningOptions();
 
-        // Resolve the effective hash: explicit user choice wins; otherwise infer from the cert
-        // (PSS params for PSS certs, key size for RSA PKCS#1; default SHA-256 for ECDSA/EdDSA).
+        // Resolve the effective hash: explicit user choice wins; if an explicit signature OID
+        // was provided, infer hash from it (RS512 → SHA512, etc.); otherwise infer from the
+        // cert (PSS params for PSS certs, key size for RSA PKCS#1; default SHA-256 for ECDSA).
         HashAlgorithmName effectiveHash = AlgorithmInference.ResolveEffectiveHashAlgorithm(
-            certificate, options.HashAlgorithm, options.HashAlgorithmExplicitlySet);
+            certificate, options.HashAlgorithm, options.HashAlgorithmExplicitlySet,
+            options.SignatureAlgorithmOid);
 
         (logger ?? NullLogger.Instance).DeferredPrepareStarted(certificate.Subject, effectiveHash.Name!);
 

--- a/src/SimpleSign.PAdES/SignerBuilder.cs
+++ b/src/SimpleSign.PAdES/SignerBuilder.cs
@@ -415,11 +415,13 @@ public sealed class SignerBuilder
 
         // Resolve the effective hash and signature OID:
         //  - If the user explicitly called WithHashAlgorithm(), the user's choice wins.
+        //  - If an explicit signature OID was provided (e.g. via WithExternalSigner), infer hash
+        //    from it (RS512 → SHA512, etc.) before falling back to cert-based inference.
         //  - Otherwise, infer from the cert (PSS params for PSS certs, key size for RSA PKCS#1).
         //  - If the user called WithSignatureAlgorithm(oid), use it (validated at CMS build time).
         //  - Otherwise, auto-detect the OID from the cert + effective hash.
         HashAlgorithmName effectiveHash = AlgorithmInference.ResolveEffectiveHashAlgorithm(
-            _certificate, _hashAlgorithm, _hashAlgorithmExplicitlySet);
+            _certificate, _hashAlgorithm, _hashAlgorithmExplicitlySet, _signatureAlgorithmOid);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
 

--- a/src/SimpleSign.PAdES/Signing/AlgorithmInference.cs
+++ b/src/SimpleSign.PAdES/Signing/AlgorithmInference.cs
@@ -10,8 +10,8 @@ namespace SimpleSign.PAdES.Signing;
 /// Shared algorithm-inference logic for all signing paths (local, external, deferred).
 /// Resolves the effective hash algorithm from the certificate when the user has not
 /// explicitly set one, implementing:
-///   - Gap 1: PSS cert's <c>RSASSA-PSS-params</c> (RFC 4055 §3.1) honoured.
-///   - Gap 3: RSA key-size-based hash selection per NIST SP 800-57 Part 1 Rev. 5.
+///   - PSS cert's <c>RSASSA-PSS-params</c> (RFC 4055 §3.1) honoured.
+///   - RSA key-size-based hash selection per NIST SP 800-57 Part 1 Rev. 5.
 /// </summary>
 internal static class AlgorithmInference
 {
@@ -24,18 +24,36 @@ internal static class AlgorithmInference
     /// <see langword="true"/> if the user explicitly called <c>WithHashAlgorithm()</c>;
     /// <see langword="false"/> if the hash is still the library default.
     /// </param>
+    /// <param name="signatureAlgorithmOid">
+    /// Optional explicit signature algorithm OID (e.g. from <c>WithExternalSigner</c>).
+    /// When provided and <paramref name="hashAlgorithmExplicitlySet"/> is <see langword="false"/>,
+    /// the hash is inferred from the OID before falling back to certificate-based inference.
+    /// </param>
     /// <returns>The effective hash algorithm to use for signing.</returns>
     internal static HashAlgorithmName ResolveEffectiveHashAlgorithm(
         X509Certificate2 cert,
         HashAlgorithmName hashAlgorithm,
-        bool hashAlgorithmExplicitlySet)
+        bool hashAlgorithmExplicitlySet,
+        string? signatureAlgorithmOid = null)
     {
         if (hashAlgorithmExplicitlySet)
         {
             return hashAlgorithm;
         }
 
-        // Gap 1: PSS cert — read hash from RSASSA-PSS-params.
+        // If the caller provided an explicit signature algorithm OID (e.g. via WithExternalSigner),
+        // infer the hash from it. This ensures the CMS digestAlgorithm matches what the
+        // external signer uses (e.g. RS512 → SHA512, not SHA256 from key-size heuristic).
+        if (signatureAlgorithmOid is not null)
+        {
+            var hashFromOid = TryInferHashFromSignatureOid(signatureAlgorithmOid);
+            if (hashFromOid is not null)
+            {
+                return hashFromOid.Value;
+            }
+        }
+
+        // PSS cert — read hash from RSASSA-PSS-params.
         // Check SubjectPublicKeyInfo OID first (RFC 4055 §4), fall back to signature
         // algorithm for self-signed PSS certs.
         if (cert.PublicKey.Oid.Value == Oids.RsaPss || cert.SignatureAlgorithm.Value == Oids.RsaPss)
@@ -46,7 +64,7 @@ internal static class AlgorithmInference
             return CryptoUtility.ParsePssHashAlgorithm(pssParams);
         }
 
-        // Gap 3: RSA PKCS#1 cert — select hash based on key size.
+        // RSA PKCS#1 cert — select hash based on key size.
         string keyOid = cert.PublicKey.Oid.Value ?? string.Empty;
         if (keyOid == Oids.RsaEncryption)
         {
@@ -56,6 +74,22 @@ internal static class AlgorithmInference
         // ECDSA, EdDSA, or unknown — keep the default (SHA-256).
         return hashAlgorithm;
     }
+
+    /// <summary>
+    /// Infers the hash algorithm from a signature algorithm OID when the hash is unambiguously
+    /// encoded in the OID (RSA PKCS#1 and ECDSA combined-hash OIDs).
+    /// Returns <see langword="null"/> for OIDs that do not encode a specific hash
+    /// (e.g. <c>id-RSASSA-PSS</c> 1.2.840.113549.1.1.10), since those require
+    /// out-of-band parameters.
+    /// </summary>
+    internal static HashAlgorithmName? TryInferHashFromSignatureOid(string sigOid) => sigOid switch
+    {
+        Oids.RsaSha256 or Oids.EcdsaSha256 => HashAlgorithmName.SHA256,
+        Oids.RsaSha384 or Oids.EcdsaSha384 => HashAlgorithmName.SHA384,
+        Oids.RsaSha512 or Oids.EcdsaSha512 => HashAlgorithmName.SHA512,
+        Oids.RsaSha1 => HashAlgorithmName.SHA1,
+        _ => null,
+    };
 
     /// <summary>
     /// Selects the appropriate hash algorithm based on the RSA key size,

--- a/src/SimpleSign.PAdES/Signing/AlgorithmInference.cs
+++ b/src/SimpleSign.PAdES/Signing/AlgorithmInference.cs
@@ -71,7 +71,13 @@ internal static class AlgorithmInference
             return SelectHashForRsaKeySize(cert);
         }
 
-        // ECDSA, EdDSA, or unknown — keep the default (SHA-256).
+        // ECDSA — select hash based on curve size per NIST SP 800-57 Part 1 Rev. 5, Table 2.
+        if (keyOid == Oids.EcPublicKey)
+        {
+            return SelectHashForEcKeySize(cert);
+        }
+
+        // EdDSA or unknown — keep the default (SHA-256).
         return hashAlgorithm;
     }
 
@@ -103,6 +109,34 @@ internal static class AlgorithmInference
             if (rsa is not null && rsa.KeySize >= 3072)
             {
                 return HashAlgorithmName.SHA384;
+            }
+        }
+        catch (CryptographicException)
+        {
+            // Fall back to SHA-256 — a safe, conservative choice.
+        }
+
+        return HashAlgorithmName.SHA256;
+    }
+
+    /// <summary>
+    /// Selects the appropriate hash algorithm based on the EC curve size,
+    /// per NIST SP 800-57 Part 1 Rev. 5, Table 2:
+    /// P-256 → SHA-256, P-384 → SHA-384, P-521 → SHA-512.
+    /// </summary>
+    private static HashAlgorithmName SelectHashForEcKeySize(X509Certificate2 cert)
+    {
+        try
+        {
+            using var ecdsa = cert.GetECDsaPublicKey();
+            if (ecdsa is not null)
+            {
+                return ecdsa.KeySize switch
+                {
+                    >= 521 => HashAlgorithmName.SHA512,
+                    >= 384 => HashAlgorithmName.SHA384,
+                    _ => HashAlgorithmName.SHA256,
+                };
             }
         }
         catch (CryptographicException)


### PR DESCRIPTION
## Context and Original Issues

This branch addresses a signature-algorithm inference gap that surfaced in external-signing workflows and could also affect EC certificates when hash selection is left to defaults.

### Issue 1: Explicit signature OID could diverge from inferred digest

When using external signing with an explicit signature algorithm OID (for example RSA SHA-512 variants), the effective hash could still be inferred from certificate heuristics (RSA key-size path), producing a mismatch between:

- the digest/hash used by CMS signed attributes, and
- the algorithm actually used by the external signer.

In practice, this can surface as Adobe/validator failures where signatures appear modified/invalid because signed-attributes verification does not reconcile.

### Issue 2: EC default inference did not account for curve strength

For id-ecPublicKey certificates, inference previously fell back to the default hash (SHA-256). That is conservative but not ideal for stronger curves and can create avoidable algorithm-strength mismatches.

## What This PR Changes

### 1. Infer hash from explicit signature OID first

Updated AlgorithmInference.ResolveEffectiveHashAlgorithm(...) to accept an optional signatureAlgorithmOid and, when hash is not explicitly user-forced, derive hash from unambiguous combined OIDs via TryInferHashFromSignatureOid(...).

Mapped OIDs include:
- RSA combined-hash OIDs: SHA-256/384/512 (+ SHA-1)
- ECDSA combined-hash OIDs: SHA-256/384/512

This ensures explicit OID intent is honored before cert-based heuristics.

### 2. Wire OID-aware inference through all relevant signing paths

Applied OID-aware inference to:
- SignerBuilder signing flow (including WithExternalSigner/WithSignatureAlgorithm usage)
- DeferredSigner prepare flow (SignatureAlgorithmOid option)

Result: effective hash and selected signature OID remain coherent across immediate and deferred paths.

### 3. Add EC curve-size based hash inference

Added SelectHashForEcKeySize(...) for id-ecPublicKey certs:
- P-256 -> SHA-256
- P-384 -> SHA-384
- P-521 -> SHA-512 (>= 521 to correctly handle P-521 key sizes)

Fallback remains SHA-256 when key metadata is unavailable.

## Files Changed

- src/SimpleSign.PAdES/Signing/AlgorithmInference.cs
  - OID-aware hash inference
  - EC curve-size based hash inference
- src/SimpleSign.PAdES/SignerBuilder.cs
  - pass signatureAlgorithmOid into effective-hash resolution
- src/SimpleSign.PAdES/DeferredSigner.cs
  - pass options.SignatureAlgorithmOid into effective-hash resolution

## Why This Improves Reliability

- Prevents digest/signature algorithm drift in external signer integrations.
- Aligns inferred hash strength with explicit OID intent.
- Improves EC defaults to track curve security level instead of always SHA-256.
- Keeps behavior backward-compatible when callers explicitly set hash algorithm.

## Diff Summary

- 3 files changed
- 82 insertions, 10 deletions